### PR TITLE
Add link anchors

### DIFF
--- a/template.html
+++ b/template.html
@@ -23,10 +23,11 @@
   <ol>
     {% for filename, line in lines.items() %}
       {% if line == current_line %}
-      <li class="selected">{{ line }}</li>
+      <li class="selected"><a name="{{ filename }}" />{{ line }}</li>
       {% else %}
       <li>
-        <a href="{{ filename }}.html">{{ line }}</a>
+        <a name="{{ filename }}" />
+        <a href="{{ filename }}.html#{{ filename }}">{{ line }}</a>
       </li>
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
This way somebody on a smaller screen hitting up e.g. ZoP number 19 will have the page load w/ the appropriate line visible.

Without it, one is always on the top of the page no matter what - fine on large enough screens, insufficient on eg my 11" MBA :)

I haven't tested this out explicitly yet :(
